### PR TITLE
Type and enable "access_token"

### DIFF
--- a/platform.schema.json
+++ b/platform.schema.json
@@ -26,6 +26,10 @@
                 "title": "Multi-Factor PIN",
                 "type": "number"
             },
+            "access_token":{
+                "title": "Access Token",
+                "type": "string"
+            },
             "googleAuth": {
                 "type": "object",
                 "properties": {

--- a/platform.schema.json
+++ b/platform.schema.json
@@ -23,7 +23,7 @@
                 }
             },
             "pin": {
-                "title": "Milti-Factor PIN",
+                "title": "Multi-Factor PIN",
                 "type": "number"
             },
             "googleAuth": {


### PR DESCRIPTION
Nest has enabled CAPTCHAs, which has means email/password will no longer work (maybe consider removing?). Using "access_token" still works as documented at https://www.reddit.com/r/homebridge/comments/ek24eh/nest_rejected_account_emailpassword/ and chrisjshull#195 and verified by commiter.

Also fixes typo.